### PR TITLE
feat: support comparing JSON object

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Language
+
+Use Japanese standard language.
+
+# Development process
+
+- Use TDD (t-wada style)
+- Use English in comment, document or some sentence in code

--- a/comparator_test.go
+++ b/comparator_test.go
@@ -1,0 +1,175 @@
+package tfdiff
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResourcesEqual_WithNestedObjects(t *testing.T) {
+	tests := []struct {
+		name     string
+		left     Resource
+		right    Resource
+		config   ComparisonConfig
+		expected bool
+	}{
+		{
+			name: "Resources with same nested objects should be equal",
+			left: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"ami":           "ami-12345",
+					"instance_type": "t2.micro",
+					"tags":          `{"Name": "test", "Environment": "dev"}`,
+				},
+			},
+			right: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"ami":           "ami-12345",
+					"instance_type": "t2.micro",
+					"tags":          `{"Name": "test", "Environment": "dev"}`,
+				},
+			},
+			config:   ComparisonConfig{IgnoreArguments: false},
+			expected: true,
+		},
+		{
+			name: "JSON objects with different key ordering but same content should be equal",
+			left: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Environment": "dev", "Name": "test"}`,
+				},
+			},
+			right: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Name": "test", "Environment": "dev"}`,
+				},
+			},
+			config:   ComparisonConfig{IgnoreArguments: false},
+			expected: true, // Should be true as JSON content is the same
+		},
+		{
+			name: "Resources with different nested objects should not be equal",
+			left: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Name": "test", "Environment": "dev"}`,
+				},
+			},
+			right: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Name": "test", "Environment": "prod"}`,
+				},
+			},
+			config:   ComparisonConfig{IgnoreArguments: false},
+			expected: false,
+		},
+		{
+			name: "Complex nested JSON should be compared correctly",
+			left: Resource{
+				Type: "aws_security_group",
+				Name: "example",
+				Config: map[string]string{
+					"ingress": `[{"from_port": 80, "to_port": 80, "protocol": "tcp", "cidr_blocks": ["0.0.0.0/0"]}]`,
+				},
+			},
+			right: Resource{
+				Type: "aws_security_group",
+				Name: "example",
+				Config: map[string]string{
+					"ingress": `[{"protocol": "tcp", "from_port": 80, "to_port": 80, "cidr_blocks": ["0.0.0.0/0"]}]`,
+				},
+			},
+			config:   ComparisonConfig{IgnoreArguments: false},
+			expected: true, // Should be true if content is same even if object order in array differs
+		},
+		{
+			name: "When IgnoreArguments is true, resources with different configs should be equal",
+			left: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Name": "test1"}`,
+				},
+			},
+			right: Resource{
+				Type: "aws_instance",
+				Name: "example",
+				Config: map[string]string{
+					"tags": `{"Name": "test2"}`,
+				},
+			},
+			config:   ComparisonConfig{IgnoreArguments: true},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourcesEqual(tt.left, tt.right, tt.config)
+			if result != tt.expected {
+				t.Errorf("resourcesEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompareResources_WithNestedObjects(t *testing.T) {
+	config := ComparisonConfig{IgnoreArguments: false}
+
+	left := []Resource{
+		{
+			Type: "aws_instance",
+			Name: "web",
+			Config: map[string]string{
+				"ami":  "ami-12345",
+				"tags": `{"Name": "web-server", "Environment": "prod"}`,
+			},
+		},
+	}
+
+	right := []Resource{
+		{
+			Type: "aws_instance",
+			Name: "web",
+			Config: map[string]string{
+				"ami":  "ami-12345",
+				"tags": `{"Environment": "prod", "Name": "web-server"}`, // Different ordering
+			},
+		},
+	}
+
+	diffs := compareResources(left, right, config)
+
+	// After fix, no differences should be detected for same JSON content with different ordering
+	if len(diffs) != 0 {
+		t.Errorf("Expected no differences for same JSON content, but got %d diffs", len(diffs))
+	}
+}
+
+func TestMapComparison(t *testing.T) {
+	// Test map comparison with reflect.DeepEqual
+	map1 := map[string]string{
+		"key1": "value1",
+		"key2": `{"a": "1", "b": "2"}`,
+	}
+
+	map2 := map[string]string{
+		"key1": "value1",
+		"key2": `{"b": "2", "a": "1"}`, // Different JSON ordering
+	}
+
+	if reflect.DeepEqual(map1, map2) {
+		t.Error("Maps with different JSON string values should not be equal")
+	}
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,39 @@
+# Basic Example - JSON Object Comparison
+
+This directory contains Terraform configurations that demonstrate tfdiff's basic functionality, particularly how it handles JSON object comparison when key ordering differs.
+
+## JSON Object Ordering Differences
+
+### aws_instance.web tags
+- **left**: `Name`, `Environment`, `Team`, `Project` ordering
+- **right**: `Project`, `Environment`, `Name`, `Team`, `Owner` ordering
+- Common tags (Name, Team, Project) are considered equal despite different ordering
+- Environment changed from "production" → "staging" (actual difference)
+- Owner tag added only in right (actual difference)
+
+
+## Usage Examples
+
+```bash
+# Basic comparison
+tfdiff left right
+
+# Resources only comparison
+tfdiff left right --level resources
+
+# Include argument differences
+tfdiff left right --ignore-args=false
+```
+
+## Expected Results
+
+JSON object ordering differences are not detected as changes, only actual content differences are shown:
+
+- aws_instance.web: 
+  - instance_type change (t2.micro → t3.small)
+  - Environment tag change (production → staging)
+  - Owner tag addition
+- aws_security_group.web_sg: Modified (ingress rules changed)
+- aws_s3_bucket.logs removal
+- aws_cloudwatch_log_group.app_logs addition
+- Other module and resource changes

--- a/examples/basic/left/main.tf
+++ b/examples/basic/left/main.tf
@@ -6,6 +6,8 @@ resource "aws_instance" "web" {
   tags = {
     Name        = "WebServer"
     Environment = "production"
+    Team        = "backend"
+    Project     = "web-app"
   }
 }
 
@@ -44,6 +46,8 @@ resource "aws_s3_bucket" "logs" {
   tags = {
     Name        = "LogsBucket"
     Environment = "production"
+    Team        = "devops"
+    Compliance  = "HIPAA"
   }
 }
 

--- a/examples/basic/right/main.tf
+++ b/examples/basic/right/main.tf
@@ -3,10 +3,13 @@ resource "aws_instance" "web" {
   ami           = "ami-0c02fb55956c7d316"
   instance_type = "t3.small" # Changed from t2.micro
 
+  # JSON object with different key ordering, but Team and Project are the same
   tags = {
-    Name        = "WebServer"
-    Environment = "staging" # Changed from production
-    Owner       = "DevOps"  # Added new tag
+    Project     = "web-app"   # Different ordering
+    Environment = "staging"   # Changed from production
+    Name        = "WebServer" # Different ordering
+    Team        = "backend"   # Different ordering
+    Owner       = "DevOps"    # Added new tag
   }
 }
 


### PR DESCRIPTION
# Description

This PR improves how tfdiff compares JSON objects in Terraform files. Before this change, complex objects like tags were treated as <complex_expression> strings, so tfdiff couldn't compare their actual content. Now tfdiff can properly compare JSON objects and detect real differences.

# What Changed

Better Object Parsing: Complex objects are now converted to JSON instead of <complex_expression> .


#  Example

```tf
  # Before: Both would show as "<complex_expression>" - no comparison possible
  # Now: tfdiff can detect actual differences in content

  # Left side
  tags = {
    Name        = "WebServer"
    Environment = "production"  # This difference will be found
    Team        = "backend"
  }

  # Right side
  tags = {
    Team        = "backend"     # Different order is OK
    Environment = "staging"     # This change will be found
    Name        = "WebServer"
    Owner       = "DevOps"      # This addition will be found
  }
```
